### PR TITLE
Clean up dangling security group rules created from K8s annotations.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
+.vscode/
 vacuum
 !internal/**

--- a/README.md
+++ b/README.md
@@ -81,3 +81,16 @@ By default, regions `eu-west-1` and `eu-west-2` will be vacuumed.  You can overr
 vacuum enis -r "us-east-1,us-east-2"
 ```
 
+### Vacuum Security Group Rules
+
+Clean up dangling security group rules which were created by K8s `aws-load-balancer-controller` via relevant annotations (e.g. resulting in descriptions like `kubernetes.io/rule/nlb/health=a6ba247c8d1e94b0691e80c29a769193`). These security group rules are created during automatic creation of NLBs and can be left dangling if the relevant services have not been shut down gracefully. Eventually you will hit the maximum number of allowed rules within your security group and need to perform a cleanup. To clean them up automatically use this:
+
+```
+vacuum securityRules
+```
+
+By default, regions `eu-west-1` and `eu-west-2` will be vacuumed.  You can override this using the regions flag:
+
+```
+vacuum securityRules -r "us-east-1,us-east-2"
+```

--- a/cmd/all.go
+++ b/cmd/all.go
@@ -8,9 +8,9 @@ import (
 var allCmd = &cobra.Command{
 	Use:   "all",
 	Short: "remove dirt from your AWS account",
-	Long:  "remove available unused rsources from your AWS account, stop lining Jeff Bezos's pockets!",
+	Long:  "remove available unused resources from your AWS account, stop lining Jeff Bezos's pockets!",
 	Run: func(cmd *cobra.Command, args []string) {
-		vacuum.Vacuum(regions, vacuum.Volumes(), vacuum.NetworkInterfaces())
+		vacuum.Vacuum(regions, vacuum.Volumes(), vacuum.NetworkInterfaces(), vacuum.SecurityRules())
 	},
 }
 

--- a/cmd/securityRules.go
+++ b/cmd/securityRules.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"github.com/kevholditch/vacuum/internal/app/vacuum"
+	"github.com/spf13/cobra"
+)
+
+// securityRulesCmd represents the securityRules command
+var securityRulesCmd = &cobra.Command{
+	Use:   "securityRules",
+	Short: "remove security rules created by K8s annotations (via aws-load-balancer-controller) which reference a removed NLB",
+	Run: func(cmd *cobra.Command, args []string) {
+		vacuum.Vacuum(regions, vacuum.SecurityRules())
+	},
+}
+
+func init() {
+	securityRulesCmd.Flags().StringSliceVarP(&regions, "regions", "r", regions, "AWS regions you want to clean e.g. eu-west-1")
+	rootCmd.AddCommand(securityRulesCmd)
+}

--- a/go.mod
+++ b/go.mod
@@ -3,18 +3,18 @@ module github.com/kevholditch/vacuum
 go 1.17
 
 require (
+	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/aws/aws-sdk-go v1.41.17
+	github.com/liamg/tml v0.4.0
+	github.com/spf13/cobra v1.2.1
 	github.com/stretchr/testify v1.7.0
 )
 
 require (
-	github.com/avast/retry-go v3.0.0+incompatible // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
-	github.com/liamg/tml v0.4.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/spf13/cobra v1.2.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -167,6 +167,7 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
@@ -175,8 +176,10 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/liamg/tml v0.4.0 h1:iZwysIBOaGz6MuaPT/+PCZgvkpgoqBu3ZI6cgApK0zc=
 github.com/liamg/tml v0.4.0/go.mod h1:0h4EAV/zBOsqI91EWONedjRpO8O0itjGJVd+wG5eC+E=
@@ -561,12 +564,14 @@ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlba
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/ini.v1 v1.62.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=

--- a/internal/app/security_rules_stage_test.go
+++ b/internal/app/security_rules_stage_test.go
@@ -1,0 +1,221 @@
+package app
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/kevholditch/vacuum/internal/app/vacuum"
+	"github.com/stretchr/testify/assert"
+)
+
+type securityRulesTestStage struct {
+	t                *testing.T
+	regions          []vacuum.Region
+	resources        vacuum.Resources
+	securityGroupdId *string
+	vpcId            *string
+}
+
+func newSecurityRulesTest(t *testing.T) (*securityRulesTestStage, *securityRulesTestStage, *securityRulesTestStage, func()) {
+	s := &securityRulesTestStage{t: t, regions: []vacuum.Region{}}
+	return s, s, s, s.clean
+}
+
+func (s *securityRulesTestStage) createEc2ServiceForRegion(region string) *ec2.EC2 {
+	mySession, err := session.NewSession(&aws.Config{
+		Region: aws.String(region),
+	})
+	if err != nil {
+		assert.Fail(s.t, err.Error())
+	}
+	return ec2.New(mySession)
+}
+
+func (s *securityRulesTestStage) createTestSecurityGroupForRegion(region string) *securityRulesTestStage {
+	s.regions = append(s.regions, vacuum.Region(region))
+	vacuumTestName := fmt.Sprintf("vacuum-test-%d", rand.Int())
+
+	svc := s.createEc2ServiceForRegion(region)
+	createVpcOutput, err := svc.CreateVpc(&ec2.CreateVpcInput{
+		CidrBlock: aws.String("10.0.0.1/16"),
+		TagSpecifications: []*ec2.TagSpecification{
+			{
+				ResourceType: aws.String("vpc"),
+				Tags: []*ec2.Tag{
+					{
+						Key:   aws.String("Name"),
+						Value: aws.String(vacuumTestName),
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		assert.Fail(s.t, err.Error())
+	}
+
+	s.vpcId = createVpcOutput.Vpc.VpcId
+	createSecurityGroupOutput, err := svc.CreateSecurityGroup(&ec2.CreateSecurityGroupInput{
+		GroupName:   aws.String(vacuumTestName),
+		Description: aws.String(vacuumTestName),
+		VpcId:       aws.String(*s.vpcId),
+	})
+
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			case "InvalidVpcID.NotFound":
+				assert.Fail(s.t, fmt.Errorf("Unable to find VPC with ID %q.", *s.vpcId).Error())
+			case "InvalidGroup.Duplicate":
+				assert.Fail(s.t, fmt.Errorf("Security group %v already exists.", vacuumTestName).Error())
+			}
+		}
+		assert.Fail(s.t, fmt.Errorf("Unable to create security group %q, %v", vacuumTestName, err).Error())
+	}
+
+	s.securityGroupdId = createSecurityGroupOutput.GroupId
+
+	return s
+}
+
+func (s *securityRulesTestStage) createTestMatchingSecurityGroupRule(region string, egress bool) *securityRulesTestStage {
+	testDescriptions := []string{
+		"kubernetes.io/rule/nlb/client=a7a67774ec364454892df58fd6be9775",
+		"kubernetes.io/rule/nlb/health=a6ba247c8d1e94b0691e80c29a769193",
+		"kubernetes.io/rule/nlb/health=d1e94b069d474e4a247c8f4454dnlg54",
+	}
+
+	s.createTestSecurityGroupRule(region, testDescriptions[rand.Intn(len(testDescriptions))], egress)
+	return s
+}
+
+func (s *securityRulesTestStage) createTestNonMatchingSecurityGroupRule(region string, egress bool) *securityRulesTestStage {
+	testDescriptions := []string{
+		"kubernetes.io/rule/nlb/mtu",
+		"some-random=label",
+		"cccccc uvtfdthketlucl kfjhhcdnlgdg dnrbirfvl lhn",
+	}
+
+	s.createTestSecurityGroupRule(region, testDescriptions[rand.Intn(len(testDescriptions))], egress)
+	return s
+}
+
+func (s *securityRulesTestStage) createTestSecurityGroupRule(region string, description string, egress bool) *securityRulesTestStage {
+	svc := s.createEc2ServiceForRegion(region)
+
+	randomPort := 30000 + rand.Intn(5000)
+	testPermissions := []*ec2.IpPermission{(&ec2.IpPermission{}).
+		SetIpProtocol("tcp").
+		SetFromPort(*aws.Int64(int64(randomPort))).
+		SetToPort(*aws.Int64(int64(randomPort))).
+		SetIpRanges([]*ec2.IpRange{
+			{
+				CidrIp:      aws.String("0.0.0.0/0"),
+				Description: aws.String(description),
+			},
+		})}
+
+	var err error
+	if egress {
+		_, err = svc.AuthorizeSecurityGroupEgress(&ec2.AuthorizeSecurityGroupEgressInput{
+			IpPermissions: testPermissions,
+			GroupId:       aws.String(*s.securityGroupdId),
+		})
+	} else {
+		_, err = svc.AuthorizeSecurityGroupIngress(&ec2.AuthorizeSecurityGroupIngressInput{
+			IpPermissions: testPermissions,
+			GroupId:       aws.String(*s.securityGroupdId),
+		})
+	}
+	if err != nil {
+		assert.Fail(s.t, err.Error())
+	}
+
+	return s
+}
+
+func (s *securityRulesTestStage) clean() {
+	for _, region := range s.regions {
+		svc := s.createEc2ServiceForRegion(string(region))
+		_, err := svc.DeleteSecurityGroup(&ec2.DeleteSecurityGroupInput{GroupId: s.securityGroupdId})
+		if err != nil {
+			assert.Fail(s.t, err.Error())
+		}
+		_, err = svc.DeleteVpc(&ec2.DeleteVpcInput{VpcId: s.vpcId})
+		if err != nil {
+			assert.Fail(s.t, err.Error())
+		}
+	}
+}
+
+func (s *securityRulesTestStage) a_security_group_with_no_rules_exists_in_region(region string) *securityRulesTestStage {
+	return s.createTestSecurityGroupForRegion(region)
+}
+
+func (s *securityRulesTestStage) a_security_group_with_no_matching_rules_exists_in_region(region string) *securityRulesTestStage {
+	return s.createTestSecurityGroupForRegion(region).
+		createTestNonMatchingSecurityGroupRule(region, true).
+		createTestNonMatchingSecurityGroupRule(region, false)
+}
+
+func (s *securityRulesTestStage) a_security_group_with_six_rules_and_three_matches_exists_in_region(region string) *securityRulesTestStage {
+	return s.createTestSecurityGroupForRegion(region).
+		createTestNonMatchingSecurityGroupRule(region, true).
+		createTestNonMatchingSecurityGroupRule(region, false).
+		createTestNonMatchingSecurityGroupRule(region, true).
+		createTestMatchingSecurityGroupRule(region, false).
+		createTestMatchingSecurityGroupRule(region, true).
+		createTestMatchingSecurityGroupRule(region, false)
+}
+
+func (s *securityRulesTestStage) a_security_group_with_six_rules_and_six_matches_exists_in_region(region string) *securityRulesTestStage {
+	return s.createTestSecurityGroupForRegion(region).
+		createTestMatchingSecurityGroupRule(region, true).
+		createTestMatchingSecurityGroupRule(region, false).
+		createTestMatchingSecurityGroupRule(region, true).
+		createTestMatchingSecurityGroupRule(region, false).
+		createTestMatchingSecurityGroupRule(region, true).
+		createTestMatchingSecurityGroupRule(region, false)
+}
+
+func (s *securityRulesTestStage) security_rules_are_identified_in(region string) *securityRulesTestStage {
+	var err error
+	s.resources, err = vacuum.SecurityRules().Identify(vacuum.Region(region))
+	assert.NoError(s.t, err)
+
+	return s
+}
+
+func (s *securityRulesTestStage) security_rules_are_vacuumed_in(region string) *securityRulesTestStage {
+	resources, err := vacuum.SecurityRules().Identify(vacuum.Region(region))
+	assert.NoError(s.t, err)
+
+	err = vacuum.SecurityRules().Clean(resources)
+	assert.NoError(s.t, err)
+
+	return s
+}
+
+func (s *securityRulesTestStage) expected_number_equals_resources_length(expected int) {
+	assert.Equal(s.t, expected, len(s.resources.Resources()))
+}
+
+func (s *securityRulesTestStage) there_should_be_no_security_rules_identified() *securityRulesTestStage {
+	s.expected_number_equals_resources_length(0)
+	return s
+}
+
+func (s *securityRulesTestStage) there_should_be_three_security_rules_identified() *securityRulesTestStage {
+	s.expected_number_equals_resources_length(3)
+	return s
+}
+
+func (s *securityRulesTestStage) there_should_be_six_security_rules_identified() *securityRulesTestStage {
+	s.expected_number_equals_resources_length(6)
+	return s
+}

--- a/internal/app/security_rules_test.go
+++ b/internal/app/security_rules_test.go
@@ -1,0 +1,113 @@
+package app
+
+import (
+	"testing"
+)
+
+func TestIdentifySecurityRulesNoRules(t *testing.T) {
+	given, when, then, clean := newSecurityRulesTest(t)
+	defer clean()
+
+	given.
+		a_security_group_with_no_rules_exists_in_region("eu-west-1")
+
+	when.
+		security_rules_are_identified_in("eu-west-1")
+
+	then.
+		there_should_be_no_security_rules_identified()
+
+}
+
+func TestIdentifySecurityRulesNoMatches(t *testing.T) {
+	given, when, then, clean := newSecurityRulesTest(t)
+	defer clean()
+
+	given.
+		a_security_group_with_no_matching_rules_exists_in_region("eu-west-1")
+
+	when.
+		security_rules_are_identified_in("eu-west-1")
+
+	then.
+		there_should_be_no_security_rules_identified()
+
+}
+
+func TestIdentifySecurityRulesSixRulesAndThreeMatches(t *testing.T) {
+	given, when, then, clean := newSecurityRulesTest(t)
+	defer clean()
+
+	given.
+		a_security_group_with_six_rules_and_three_matches_exists_in_region("eu-west-1")
+
+	when.
+		security_rules_are_identified_in("eu-west-1")
+
+	then.
+		there_should_be_three_security_rules_identified()
+
+}
+
+func TestIdentifySecurityRulesSixRulesAndSixMatches(t *testing.T) {
+	given, when, then, clean := newSecurityRulesTest(t)
+	defer clean()
+
+	given.
+		a_security_group_with_six_rules_and_six_matches_exists_in_region("eu-west-1")
+
+	when.
+		security_rules_are_identified_in("eu-west-1")
+
+	then.
+		there_should_be_six_security_rules_identified()
+
+}
+
+func TestRemoveSecurityRulesSixRulesAndNoMatches(t *testing.T) {
+	given, when, then, clean := newSecurityRulesTest(t)
+	defer clean()
+
+	given.
+		a_security_group_with_no_matching_rules_exists_in_region("eu-west-1")
+
+	when.
+		security_rules_are_vacuumed_in("eu-west-1")
+
+	then.
+		security_rules_are_identified_in("eu-west-1").
+		there_should_be_no_security_rules_identified()
+
+}
+
+func TestRemoveSecurityRulesSixRulesAndThreeMatches(t *testing.T) {
+	given, when, then, clean := newSecurityRulesTest(t)
+	defer clean()
+
+	given.
+		a_security_group_with_six_rules_and_three_matches_exists_in_region("eu-west-1")
+
+	when.
+		security_rules_are_vacuumed_in("eu-west-1")
+
+	then.
+		security_rules_are_identified_in("eu-west-1").
+		there_should_be_no_security_rules_identified()
+
+}
+
+func TestRemoveSecurityRulesSixRulesAndSixMatches(t *testing.T) {
+	given, when, then, clean := newSecurityRulesTest(t)
+	defer clean()
+
+	given.
+		a_security_group_with_six_rules_and_six_matches_exists_in_region("eu-west-1")
+
+	when.
+		security_rules_are_vacuumed_in("eu-west-1")
+
+	then.
+		security_rules_are_identified_in("eu-west-1").
+		there_should_be_no_security_rules_identified()
+
+}

--- a/internal/app/vacuum/security_rules.go
+++ b/internal/app/vacuum/security_rules.go
@@ -1,0 +1,182 @@
+package vacuum
+
+import (
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/elb"
+	"github.com/aws/aws-sdk-go/service/elbv2"
+)
+
+func createELBServiceForRegion(region Region) (*elb.ELB, error) {
+	mySession, err := session.NewSession(&aws.Config{
+		Region: aws.String(string(region)),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return elb.New(mySession), nil
+}
+
+type securityRuleVacuumer struct{}
+
+type securityRuleResource struct {
+	id *string
+}
+
+func (s *securityRuleResource) ID() *string {
+	return s.id
+}
+
+func SecurityRules() Vacuumer {
+	return &securityRuleVacuumer{}
+}
+
+func (s *securityRuleVacuumer) Type() string {
+	return "security rules"
+}
+
+func (s *securityRuleVacuumer) Identify(region Region) (Resources, error) {
+	svc, err := createEc2ServiceForRegion(region)
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := svc.DescribeSecurityGroupRules(&ec2.DescribeSecurityGroupRulesInput{})
+	if err != nil {
+		return nil, err
+	}
+
+	result := &resources{
+		resources: []Resource{},
+		region:    region,
+	}
+	for _, rule := range response.SecurityGroupRules {
+		removeable, err := securityGroupRuleCanBeRemoved(rule, region)
+		if err != nil {
+			return nil, err
+		}
+		if !removeable {
+			continue
+		}
+		result.resources = append(result.resources, &securityRuleResource{id: rule.SecurityGroupRuleId})
+	}
+
+	return result, nil
+}
+
+func securityGroupRuleCanBeRemoved(rule *ec2.SecurityGroupRule, region Region) (bool, error) {
+	k8sManaged, nlbID := securityGroupRuleCreatedByK8sManagedNLB(rule)
+	if k8sManaged {
+		nlbExists, err := nlbExists(nlbID, region)
+		if err != nil {
+			return false, err
+		}
+		if nlbExists {
+			return false, nil
+		}
+
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func securityGroupRuleCreatedByK8sManagedNLB(rule *ec2.SecurityGroupRule) (bool, *string) {
+	// Example descriptions we are expecting to be able to handle:
+	// kubernetes.io/rule/nlb/client=a7a67774ec364454892df58fd6be9775
+	// kubernetes.io/rule/nlb/health=a6ba247c8d1e94b0691e80c29a769193
+	if rule.Description == nil || !strings.HasPrefix(*rule.Description, "kubernetes.io/rule/nlb") {
+		return false, nil
+	}
+
+	splitK8sDescription := strings.Split(*rule.Description, "=")
+	if len(splitK8sDescription) == 1 {
+		return false, nil
+	}
+
+	nlb := splitK8sDescription[len(splitK8sDescription)-1]
+	return true, &nlb
+}
+
+func nlbExists(nlbID *string, region Region) (bool, error) {
+	svc, err := createELBServiceForRegion(region)
+	if err != nil {
+		return false, nil
+	}
+	_, err = svc.DescribeLoadBalancerAttributes(&elb.DescribeLoadBalancerAttributesInput{
+		LoadBalancerName: nlbID,
+	})
+
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok {
+			if awsErr.Code() == elbv2.ErrCodeLoadBalancerNotFoundException {
+				return false, nil
+			}
+		}
+		return false, err
+	}
+
+	return true, nil
+}
+
+func (s *securityRuleVacuumer) Clean(resources Resources) error {
+	svc, err := createEc2ServiceForRegion(resources.Region())
+	if err != nil {
+		return err
+	}
+
+	var ruleIds []*string
+	for _, resource := range resources.Resources() {
+		ruleIds = append(ruleIds, resource.ID())
+	}
+
+	rulesResponse, err := svc.DescribeSecurityGroupRules(&ec2.DescribeSecurityGroupRulesInput{
+		SecurityGroupRuleIds: ruleIds,
+	})
+	if err != nil {
+		return err
+	}
+
+	egressRules, ingressRules := rulesSplitByEgressIngress(rulesResponse.SecurityGroupRules)
+
+	for groupID, ruleIDs := range egressRules {
+		_, err = svc.RevokeSecurityGroupEgress(&ec2.RevokeSecurityGroupEgressInput{
+			GroupId:              &groupID,
+			SecurityGroupRuleIds: ruleIDs,
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	for groupID, ruleIDs := range ingressRules {
+		_, err = svc.RevokeSecurityGroupIngress(&ec2.RevokeSecurityGroupIngressInput{
+			GroupId:              &groupID,
+			SecurityGroupRuleIds: ruleIDs,
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func rulesSplitByEgressIngress(rules []*ec2.SecurityGroupRule) (egressRules map[string][]*string, ingressRules map[string][]*string) {
+	egressRules = make(map[string][]*string)
+	ingressRules = make(map[string][]*string)
+
+	for _, rule := range rules {
+		if *rule.IsEgress {
+			egressRules[*rule.GroupId] = append(egressRules[*rule.GroupId], rule.SecurityGroupRuleId)
+		} else {
+			ingressRules[*rule.GroupId] = append(ingressRules[*rule.GroupId], rule.SecurityGroupRuleId)
+		}
+	}
+
+	return egressRules, ingressRules
+}

--- a/internal/app/vacuum/version.go
+++ b/internal/app/vacuum/version.go
@@ -1,5 +1,5 @@
 package vacuum
 
 func Version() string {
-	return "v0.0.5"
+	return "v0.0.6"
 }


### PR DESCRIPTION
Clean up dangling security group rules which were created by K8s `aws-load-balancer-controller` via relevant annotations (e.g. resulting in descriptions like `kubernetes.io/rule/nlb/health=a6ba247c8d1e94b0691e80c29a769193`). These security group rules are created during automatic creation of NLBs and can be left dangling if the relevant services have not been shut down gracefully. Eventually you will hit the maximum number of allowed rules within your security group and need to perform a cleanup.